### PR TITLE
FIX: Declared $Log variable for the email attachment

### DIFF
--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -77,7 +77,11 @@ $ExcludeString = $ExcludeString.Substring(0, $ExcludeString.Length - 1)
 
 # Set the staging directory and name the backup file or folder. 
 $BackupName = "Backup-$(Get-Date -format yyyy-MM-dd-hhmmss)"
-$ZipFileName = "$($BackupName).zip"
+if ($Use7ZIP) {
+    $ZipFileName = "$($BackupName).7z"
+} else {
+    $ZipFileName = "$($BackupName).zip"
+}
 if ($UseStaging -and $Zip) {
     $BackupDir = "$StagingDir"
 } else {

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -42,7 +42,7 @@ Param(
 
     # Zip
     [bool]$Zip = $True, # Zip the backup. 
-    [bool]$Use7ZIP = $False, # Make sure 7-Zip is installed. (https://7-zip.org)
+    [bool]$Use7zip = $False, # Make sure 7-Zip is installed. (https://7-zip.org)
     [string]$7zPath = "$env:ProgramFiles\7-Zip\7z.exe",
     [string]$Versions = "2", # Number of backups you want to keep. 
 
@@ -322,7 +322,7 @@ if (-not $CheckDir) {
     if ($Zip) {
         $ZipStartDate = Get-Date
         Write-au2matorLog -Type INFO -Text "Compressing the Backup Destination"
-        if ($Use7ZIP) {
+        if ($Use7zip) {
             Write-au2matorLog -Type DEBUG -Text "Use 7-Zip"
             if (test-path $7zPath) { 
                 Write-au2matorLog -Type DEBUG -Text "7-Zip found: $($7zPath)!" 
@@ -331,20 +331,20 @@ if (-not $CheckDir) {
             } else {
                 Write-au2matorLog -Type DEBUG -Text "Looking for 7-Zip here: $($7zPath)" 
                 Write-au2matorLog -Type ERROR -Text "7-Zip not found: Reverting to Powershell compression" 
-				$Use7ZIP = $FALSE
+				$Use7zip = $FALSE
             }
-            if ($Use7ZIP -and $UseStaging) { # Zip to the staging directory, then move to the destination.
+            if ($Use7zip -and $UseStaging) { # Zip to the staging directory, then move to the destination.
                 # Usage: sz a -t7z <archive.zip> <source1> <source2> <sourceX>
-                sz a -t7z "$BackupDir\$ZipFileName" $BackupDir
+                sz a -t7z "$BackupDir\$ZipFileName" "$BackupDir\*"
                 Write-au2matorLog -Type INFO -Text "Moving Zip to $Destination"
                 Move-Item -Path "$BackupDir\$ZipFileName" -Destination $Destination
 
             } else { # Zip straight to the BackupDir. 
-                sz a -t7z "$BackupDir\$ZipFileName" $BackupDir
+                sz a -t7z "$BackupDir\$ZipFileName" "$BackupDir\*"
             }
             
         }
-		if (-not $Use7ZIP) {  # Use powershell-native compression
+		if (-not $Use7zip) {  # Use powershell-native compression
 			Write-au2matorLog -Type DEBUG -Text "Using Powershell Compress-Archive"
 			#Write-au2matorLog -Type DEBUG -Text "BackupDir = $($BackupDir)"
 			#Write-au2matorLog -Type DEBUG -Text "StagingDir = $($StagingDir)"

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -417,7 +417,6 @@ if (-not $CheckDir) {
 						Computer: $env:COMPUTERNAME`n
 						Source(s): $BackupDirs`n
 						Backup Location: $Destination`n
-						Backup Location: $Destination`n
 						Archive Password: $Password`n
 						$ZipRemovalInfo`n
 						$FolderRemovalInfo"

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -57,7 +57,7 @@ Param(
 	[string]$Password = "Password", # Specify password ' will be ignored if RandomPw=$True
 	[bool]$UseRandomPw = $True, # Specify password or use Random - ignores the previous string
 	[string]$RandomPwLength = "10", # Specify password or use Random - ignores the previous string
-	[string]$RandomPwCharacters = "abcdefghiklmnoprstuvwxyzABCDEFGHKLMNOPRSTUVWXYZ1234567890!%$", # Available characters for the random password generator
+	[string]$RandomPwCharset = "abcdefghiklmnoprstuvwxyzABCDEFGHKLMNOPRSTUVWXYZ1234567890!%$", # Available characters for the random password generator
 
     # Email
     [bool]$SendEmail = $False, # $True will send report via email (SMTP send)
@@ -340,7 +340,7 @@ if (-not $CheckDir) {
 						}
 						
 						Write-au2matorLog -Type INFO -Text "Generating Random Password"
-						$SemiRandom = Get-RandomCharacters -length $RandomPwLength -characters $RandomPwCharacters
+						$SemiRandom = Get-RandomCharacters -length $RandomPwLength -characters $($RandomPwCharset * 64)
 						$Password = Scramble-String $SemiRandom
 					}
 				$7zipArgs = "a","-mx=$7zCompression","-t7z","-p$Password","-mhe","em=AES256"

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -78,11 +78,6 @@ $ExcludeString = $ExcludeString.Substring(0, $ExcludeString.Length - 1)
 
 # Set the staging directory and name the backup file or folder. 
 $BackupName = "Backup-$(Get-Date -format yyyy-MM-dd-hhmmss)"
-if ($Use7ZIP) {
-    $ZipFileName = "$($BackupName).7z"
-} else {
-    $ZipFileName = "$($BackupName).zip"
-}
 if ($UseStaging -and $Zip) {
     $BackupDir = "$StagingDir"
 } else {
@@ -338,6 +333,11 @@ if (-not $CheckDir) {
                 Write-au2matorLog -Type ERROR -Text "7-Zip not found: Reverting to Powershell compression" 
 				$Use7zip = $FALSE
             }
+			if ($Use7ZIP) {
+				$ZipFileName = "$($BackupName).7z"
+			} else {
+				$ZipFileName = "$($BackupName).zip"
+			}
             if ($Use7zip -and $UseStaging) { # Zip to the staging directory, then move to the destination.
                 # Usage: sz a -mx=$7zCompression -t7z <archive.zip> <source1> <source2> <sourceX>
                 sz a -mx=$7zCompression -t7z "$BackupDir\$ZipFileName" "$BackupDir\*"

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -269,7 +269,7 @@ Function Make-Backup {
 
     # Send e-mail with reports as attachments
     if ($SendEmail -eq $True) {
-        $EmailSubject = "$env:COMPUTERNAME - Backup on $(get-date -format yyyy.MM.dd)"
+        $EmailSubject = "$env:COMPUTERNAME \ $BackupDirs - Backup on $(get-date -format yyyy.MM.dd)"
         $EmailBody = "Backup Script $(get-date -format yyyy.MM.dd) (last Month).`n
                       Computer: $env:COMPUTERNAME`n
                       Source(s): $BackupDirs`n

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -45,6 +45,7 @@ Param(
     [bool]$Use7zip = $False, # Make sure 7-Zip is installed. (https://7-zip.org)
     [string]$7zPath = "$env:ProgramFiles\7-Zip\7z.exe",
     [string]$Versions = "2", # Number of backups you want to keep. 
+    [string]$7zCompression = "9", # 7-Zip compression level: 0 for archival, 9 for Ultra
 
     # Staging -- Only used if Zip = $True.
     [bool]$UseStaging = $True, # If $False: $Destination will be used for Staging.
@@ -331,20 +332,20 @@ if (-not $CheckDir) {
             if (test-path $7zPath) { 
                 Write-au2matorLog -Type DEBUG -Text "7-Zip found: $($7zPath)!" 
                 set-alias sz "$7zPath"
-                #sz a -t7z "$directory\$zipfile" "$directory\$name"    
+                #sz a -mx=$7zCompression -t7z "$directory\$zipfile" "$directory\$name"    
             } else {
                 Write-au2matorLog -Type DEBUG -Text "Looking for 7-Zip here: $($7zPath)" 
                 Write-au2matorLog -Type ERROR -Text "7-Zip not found: Reverting to Powershell compression" 
 				$Use7zip = $FALSE
             }
             if ($Use7zip -and $UseStaging) { # Zip to the staging directory, then move to the destination.
-                # Usage: sz a -t7z <archive.zip> <source1> <source2> <sourceX>
-                sz a -t7z "$BackupDir\$ZipFileName" "$BackupDir\*"
+                # Usage: sz a -mx=$7zCompression -t7z <archive.zip> <source1> <source2> <sourceX>
+                sz a -mx=$7zCompression -t7z "$BackupDir\$ZipFileName" "$BackupDir\*"
                 Write-au2matorLog -Type INFO -Text "Moving Zip to $Destination"
                 Move-Item -Path "$BackupDir\$ZipFileName" -Destination $Destination
 
             } else { # Zip straight to the BackupDir. 
-                sz a -t7z "$BackupDir\$ZipFileName" "$BackupDir\*"
+                sz a -mx=$7zCompression -t7z "$BackupDir\$ZipFileName" "$BackupDir\*"
             }
             
         }

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -1,7 +1,7 @@
 ﻿########################################################
 # Name: BackupScript.ps1                              
-# Version: 2.1
-# LastModified: 2020-07-06
+# Version: 2.2
+# LastModified: 2020-08-19
 # GitHub: https://github.com/vvildcard/PowerShell-Backup-Script
 # 
 # 
@@ -275,7 +275,7 @@ Function Make-Backup {
                       Source(s): $BackupDirs`n
                       Backup Location: $Destination"
         Write-au2matorLog -Type INFO -Text "Sending e-mail to $EmailTo from $EmailFrom (SMTPServer = $EmailSMTP) "
-        # The attachment is $log 
+        $Log=$logPath + "\" + (Get-Date -format yyyyMMdd) + "_" + $LogfileName + ".log"
         Send-MailMessage -To $EmailTo -From $EmailFrom -Subject $EmailSubject -Body $EmailBody -SmtpServer $EmailSMTP -attachment $Log 
     }
 }

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -83,8 +83,8 @@ foreach ($Entry in $ExcludeDirs) {
 $ExcludeString = $ExcludeString.Substring(0, $ExcludeString.Length - 1)
 [RegEx]$exclude = $ExcludeString
 
-# Set the staging directory and name the backup file or folder. 
-$BackupName = "Backup-$(Get-Date -format yyyy-MM-dd-hhmmss)"
+# Set the staging directory and name the backup file or folder.
+$BackupName = "$($BackupDirs -replace '(.{8}).+','$1')","-Backup-$(Get-Date -format yyyy-MM-dd)" -join ""
 if ($UseStaging -and $Zip) {
     $BackupDir = "$StagingDir"
 } else {

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 # Version 2.2 (2020-08-19)
 	FIX: Declared $Log variable for the email attachment
 	FIX: Don't include parent folder in the archive when using 7-Zip
+	CHANGE: Uze .7z extension when using 7-Zip
 
 # Version 2.1 (2020-07-06)
 	FIX: ERROR, WARNING and INFO log levels work for console output (the log is always DEBUG level)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@
     LogFileName (Default: "Log")
     LoggingLevel (Default: 2)
     Zip (Default: $True)
-    Use7ZIP (Default: $False
+    Use7ZIP (Default: $False)
     7zPath (Default: "$env:ProgramFiles\7-Zip\7z.exe")
+	$7zCompression (Default: 9, Ultra)
     Versions (Default: "2") *Bug*: It will actually keep X+1 backups
     UseStaging (Default: $True)
     StagingDir (Default: "$TempDir\Staging")
@@ -41,6 +42,7 @@
 	FIX: Declared $Log variable for the email attachment
 	FIX: Don't include parent folder in the archive when using 7-Zip
 	CHANGE: Uze .7z extension when using 7-Zip
+	NEW: 7-Zip compression level
 
 # Version 2.1 (2020-07-06)
 	FIX: ERROR, WARNING and INFO log levels work for console output (the log is always DEBUG level)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Name: BackupScript.ps1
-    Version: 2.2
+    Version: 2.3
     LastModified: 2020-08-19
 
 # Description
@@ -37,6 +37,10 @@
     EmailTo (Default: "test@domain.com")
     EmailFrom (Default: "from@domain.com")
     EmailSMTP (Default; "smtp.domain.com")
+	
+# Version 2.3 (2020-08-19)
+	NEW: Implemented 7-Zip encryption option
+	FIX: Small e-mail send improvements
 	
 # Version 2.2 (2020-08-19)
 	FIX: Declared $Log variable for the email attachment

--- a/README.md
+++ b/README.md
@@ -37,15 +37,16 @@
     EmailFrom (Default: "from@domain.com")
     EmailSMTP (Default; "smtp.domain.com")
 	
-# Version 2.2 (2020-07-06)
+# Version 2.2 (2020-08-19)
 	FIX: Declared $Log variable for the email attachment
+	FIX: Don't include parent folder in the archive when using 7-Zip
 
 # Version 2.1 (2020-07-06)
 	FIX: ERROR, WARNING and INFO log levels work for console output (the log is always DEBUG level)
 	DIF: Adjusted some logging output levels. 
 	DIF: Set LogLevel default to 2 (INFO). 
 
-# Version 2.0 (2020.07.02)
+# Version 2.0 (2020-07-02)
     NEW: All configurable variables are parameters. 
     FIX: Removed all author/computer-specific paths and messages. 
     FIX: Typos

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Name: BackupScript.ps1
-    Version: 2.0
-    LastModified: 2020-07-06
+    Version: 2.2
+    LastModified: 2020-08-19
 
 # Description
     Copies one or more BackupDirs to the Destination.
@@ -36,6 +36,9 @@
     EmailTo (Default: "test@domain.com")
     EmailFrom (Default: "from@domain.com")
     EmailSMTP (Default; "smtp.domain.com")
+	
+# Version 2.2 (2020-07-06)
+	FIX: Declared $Log variable for the email attachment
 
 # Version 2.1 (2020-07-06)
 	FIX: ERROR, WARNING and INFO log levels work for console output (the log is always DEBUG level)


### PR DESCRIPTION
Sorry about the previous pull request, it wasn't correct.

$Log wasn't declared for the email attachment, I made a dirty fix, as $LogFilePath is only declared in the logging function and couldn't be used.